### PR TITLE
Disable auto fleets, show drag path and combat preview

### DIFF
--- a/client/src/game/Territory.js
+++ b/client/src/game/Territory.js
@@ -189,7 +189,7 @@ export class Territory {
             this.lastArmyGeneration = this.lastArmyGeneration % effectiveGenerationRate;
             
             // Check if this territory has an active supply route
-            if (game && game.supplySystem && game.supplySystem.isSupplySource(this.id)) {
+            if (game && game.autoMoveEnabled && game.supplySystem && game.supplySystem.isSupplySource(this.id)) {
                 const destinationId = game.supplySystem.getSupplyDestination(this.id);
                 const destinationTerritory = game.gameMap.territories[destinationId];
                 
@@ -234,7 +234,7 @@ export class Territory {
             }
             
             // Check for fleet overflow after army generation
-            if (game) {
+            if (game && game.autoMoveEnabled) {
                 this.checkFleetOverflow(game);
             }
         }


### PR DESCRIPTION
## Summary
- disable overflow and supply moves by default
- highlight drag path between stars
- block commands if no connected warp path
- show combat preview while dragging

## Testing
- `npm run check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6875624228c4832295a83eab5a92a076